### PR TITLE
feat(scale): exports paddingBottom; cleans up type names

### DIFF
--- a/src/scale.test.ts
+++ b/src/scale.test.ts
@@ -1,4 +1,24 @@
-import { scale } from "./scale";
+import { scale, paddingBottom } from "./scale";
+
+describe("paddingBottom", () => {
+  it("calculates a correct value for paddingBottom (1)", () => {
+    expect(paddingBottom({ width: 300, height: 300 })).toBe("100%");
+  });
+
+  it("calculates a correct value for paddingBottom (2)", () => {
+    expect(paddingBottom({ width: 300, height: 400 })).toBe(
+      "133.33333333333331%"
+    );
+  });
+
+  it("calculates a correct value for paddingBottom (3)", () => {
+    expect(paddingBottom({ width: 400, height: 300 })).toBe("75%");
+  });
+
+  it("calculates a correct value for paddingBottom (4)", () => {
+    expect(paddingBottom({ width: 3000, height: 300 })).toBe("10%");
+  });
+});
 
 describe("scale", () => {
   it("calculates width and height correctly", () => {

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -1,11 +1,11 @@
-export type Required = { width: number; height: number };
+export type AspectDimensions = { width: number; height: number };
 
-export type Scale = (
+export type MaxDimensions =
   | { maxHeight: number; maxWidth: number }
   | { maxHeight: number }
-  | { maxWidth: number }
-) &
-  Required;
+  | { maxWidth: number };
+
+export type Scale = AspectDimensions & MaxDimensions;
 
 export const factor = ({ width, height, ...dimensions }: Scale): number => {
   if ("maxHeight" in dimensions && !("maxWidth" in dimensions))
@@ -16,6 +16,9 @@ export const factor = ({ width, height, ...dimensions }: Scale): number => {
 
   return Math.min(dimensions.maxWidth / width, dimensions.maxHeight / height);
 };
+
+export const paddingBottom = ({ width, height }: AspectDimensions) =>
+  `${(height / width) * 100.0}%`;
 
 export const scale = ({
   width,
@@ -30,7 +33,11 @@ export const scale = ({
   const scale = factor({ width, height, ...dimensions });
   const scaledWidth = Math.floor(width * scale);
   const scaledHeight = Math.floor(height * scale);
-  const paddingBottom = `${(height / width) * 100.0}%`;
 
-  return { width: scaledWidth, height: scaledHeight, paddingBottom, scale };
+  return {
+    width: scaledWidth,
+    height: scaledHeight,
+    paddingBottom: paddingBottom({ width, height }),
+    scale,
+  };
 };


### PR DESCRIPTION
Given the use case of wanting to support maxWidths of 100% — export the paddingBottom function which
is the only necessary piece.

BREAKING CHANGE: An exported type is re-named for clarity: `Required` becomes `AspectDimensions` (it's safe to
ignore this if you don't import the type)